### PR TITLE
Add tool now ends with newline

### DIFF
--- a/reminder.sh
+++ b/reminder.sh
@@ -57,10 +57,11 @@ add_reminder(){
 	TYPE=$(printf "%s" "$ADD" | awk 'BEGIN {FS="|" } {print $2 }')
 	DESC=$(printf "%s" "$ADD" | awk 'BEGIN {FS="|" } {print $3 }')
 	DATE=$(printf "%s" "$ADD" | awk 'BEGIN {FS="|" } {print $4 }')
-	printf "\nFALSE '%s' '%s' '%s' %s" "$CATY" "$TYPE" "$DESC" "$DATE" >> $FILE
+	printf "FALSE '%s' '%s' '%s' %s\n" "$CATY" "$TYPE" "$DESC" "$DATE" >> $FILE
 	printf "Added: '%s' '%s' '%s' %s to your tasks\n" "$CATY" "$TYPE" "$DESC" "$DATE"
 }
 if [ ! -z $ADDMODE ]; then
+	printf "\n" >> $FILE #in case last edit did not end with newline
 	while true; do
 		add_reminder
 	done


### PR DESCRIPTION
address issue #6 
add a newline at the end of a new task rather than the begining
add a newline when first entering add mode to enable backward compatibility and fix previously broken lists